### PR TITLE
Added dynamic subclassing for mixing in to individual instances of objects at init time

### DIFF
--- a/ObjectiveMixin.xcodeproj/project.pbxproj
+++ b/ObjectiveMixin.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7D7CA7DA15125C990014D312 /* Mixin.h in Headers */ = {isa = PBXBuildFile; fileRef = E7DE3B5413165FB500C96724 /* Mixin.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E77203231352FCE000C1B257 /* Cocoa.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = E77203221352FCE000C1B257 /* Cocoa.framework */; };
 		E772032D1352FCE000C1B257 /* InfoPlist.strings in Resources */ = {isa = PBXBuildFile; fileRef = E772032B1352FCE000C1B257 /* InfoPlist.strings */; };
 		E77203301352FCE000C1B257 /* ObjectiveMixinTests.h in Resources */ = {isa = PBXBuildFile; fileRef = E772032F1352FCE000C1B257 /* ObjectiveMixinTests.h */; };
@@ -269,6 +270,7 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7D7CA7DA15125C990014D312 /* Mixin.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -506,14 +508,13 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				DSTROOT = /tmp/ObjectiveMixinCocoaTouch.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ObjectiveMixinCocoaTouch/ObjectiveMixinCocoaTouch-Prefix.pch";
 				GCC_SYMBOLS_PRIVATE_EXTERN = NO;
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/ObjectiveMixin;
 				SDKROOT = iphoneos;
 			};
 			name = Debug;
@@ -523,13 +524,12 @@
 			buildSettings = {
 				ALWAYS_SEARCH_USER_PATHS = NO;
 				ARCHS = "$(ARCHS_STANDARD_32_BIT)";
-				DSTROOT = /tmp/ObjectiveMixinCocoaTouch.dst;
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "ObjectiveMixinCocoaTouch/ObjectiveMixinCocoaTouch-Prefix.pch";
-				GCC_VERSION = com.apple.compilers.llvmgcc42;
 				IPHONEOS_DEPLOYMENT_TARGET = 4.3;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PUBLIC_HEADERS_FOLDER_PATH = /usr/local/include/ObjectiveMixin;
 				SDKROOT = iphoneos;
 			};
 			name = Release;

--- a/ObjectiveMixin.xcodeproj/project.pbxproj
+++ b/ObjectiveMixin.xcodeproj/project.pbxproj
@@ -60,7 +60,7 @@
 		E772034E13530A6700C1B257 /* ObjectiveMixinCocoaTouch-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ObjectiveMixinCocoaTouch-Prefix.pch"; sourceTree = "<group>"; };
 		E772037413530B0600C1B257 /* ObjectiveMixinCocoa.dylib */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.dylib"; includeInIndex = 0; path = ObjectiveMixinCocoa.dylib; sourceTree = BUILT_PRODUCTS_DIR; };
 		E772037813530B0600C1B257 /* ObjectiveMixinCocoa-Prefix.pch */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "ObjectiveMixinCocoa-Prefix.pch"; sourceTree = "<group>"; };
-		E772037D1353198600C1B257 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; };
+		E772037D1353198600C1B257 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = text; path = README.md; sourceTree = "<group>"; wrapsLines = 1; };
 		E772037E135334B300C1B257 /* ChildSourceClass.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = ChildSourceClass.h; sourceTree = "<group>"; };
 		E772037F135334B300C1B257 /* ChildSourceClass.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ChildSourceClass.m; sourceTree = "<group>"; };
 		E77355D3135721700062EB8A /* ObjectiveMixinExamples */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = ObjectiveMixinExamples; sourceTree = BUILT_PRODUCTS_DIR; };

--- a/ObjectiveMixin/Mixin.h
+++ b/ObjectiveMixin/Mixin.h
@@ -9,9 +9,7 @@
 #import <Foundation/Foundation.h>
 
 
-@interface Mixin : NSObject {
-	
-}
+@interface Mixin : NSObject
 
 + (void) from:(Class)sourceClass into:(Class)destinationClass;
 + (void) from:(Class)sourceClass into:(Class)destinationClass followInheritance:(BOOL)followInheritance;
@@ -24,5 +22,9 @@
 
 - (void) mixinFrom:(Class)sourceClass;
 - (void) mixinFrom:(Class)sourceClass followInheritance:(BOOL)followInheritance;
+
+
++ (id) allocWithSuperclass:(Class)superClass;
++ (Class) classWithSuperclass:(Class)superClass;
 
 @end

--- a/README.md
+++ b/README.md
@@ -79,5 +79,63 @@ This is just another mechanism you can use when designing your class hierarchy, 
 
 Fun!
 
+
+
+
+Update by Jamie Montgomerie
+---------------------------
+
+Dynamic Subclassing
+-------------------
+
+It's now also possible to dynamically create a subclass at runtime.  In some ways, this is akin to being able to create concrete methods in protocols.
+
+For example, you might declare a UIView mixin that stores a block that will be called in place of -drawRect: like this:
+
+    @protocol THDrawRectWithBlocks <NSObject>
+    @property (nonatomic, copy) void(^drawRectBlock)(UIView *self, CGRect rect);
+    @end
+
+    @interface THDrawRectWithBlocksMixin : UIView <ArvoDrawRectWithBlocks>
+    @end
+
+Implemented like this:
+
+    @implementation THDrawRectWithBlocksMixin
+
+    @synthesize drawRectBlock;
+
+    - (void)drawRect:(CGRect)rect
+    {
+        self.drawRectBlock(self, rect);
+    }
+
+    @end
+
+You can then instantiate objects using the -allocWithSuperclass: method.  For example, this will create a UIButton that has the methods from your THDrawRectWithBlocks class:
+
+    UIButton<THDrawRectWithBlocks> *button = [(UIButton<THDrawRectWithBlocks> *)[ArvoDrawRectWithBlocksMixin allocWithSuperclass:[UIButton class]] initWithFrame:self.view.bounds];
+    
+    button.drawRectBlock = ^(UIView *view, CGRect rect) {
+        [[UIColor redColor] set];
+        UIRectFill(rect);
+    };
+    
+Because the subclass is a 'real' subclass, even though it's created at runtime, it is possible (as in the above example) to declare properties and even ivars in the mixin class.
+    
+If you name your class with a "Mixin" suffix, and your protocol without one (as in this example), Objective Mixin will ensure that the dynamicly created class is correctly marked as conforming to the protocol (so, in thie example, objects will respond to [button conformsToProtocol:@protocol(THDrawRectWithBlocks)] with YES).
+
+Note that calling 'super' in your mixin code will, at runtime, call the method of the _dynamic_ superclass (so, in this case, it would be _UIButton's_ methods that would be called, _not UIView's_).
+
+
+More than one dynamic superclass
+--------------------------------
+
+The convenience -allocWithSuperclass: method isn't powerful enough to allow more than one dynamic superclass, but you can use the more general -classWithSuperclass: method to 'chain' mixins, like this:
+
+    [[MySecondUIViewMixin classWithSuperclass:[MyFirstUIViewMixin classWithSuperclass:UIView] alloc] init];
+
+
+
 [1]: http://www.ruby-doc.org/docs/ProgrammingRuby/html/tut_modules.html
 [2]: https://developer.apple.com/library/ios/#documentation/Cocoa/Reference/ObjCRuntimeRef/Reference/reference.html

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You can then instantiate objects using the -allocWithSuperclass: method.  For ex
     
 Because the subclass is a 'real' subclass, even though it's created at runtime, it is possible (as in the above example) to declare properties and even ivars in the mixin class.
     
-If you name your class with a "Mixin" suffix, and your protocol without one (as in this example), Objective Mixin will ensure that the dynamicly created class is correctly marked as conforming to the protocol (so, in thie example, objects will respond to [button conformsToProtocol:@protocol(THDrawRectWithBlocks)] with YES).
+If you name your class with a "Mixin" suffix, and your protocol without one (as in this example), Objective Mixin will ensure that the dynamically created class is correctly marked as conforming to the protocol (so, in thie example, objects will respond to [button conformsToProtocol:@protocol(THDrawRectWithBlocks)] with YES).
 
 Note that calling 'super' in your mixin code will, at runtime, call the method of the _dynamic_ superclass (so, in this case, it would be _UIButton's_ methods that would be called, _not UIView's_).
 

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ For example, you might declare a UIView mixin that stores a block that will be c
     @property (nonatomic, copy) void(^drawRectBlock)(UIView *self, CGRect rect);
     @end
 
-    @interface THDrawRectWithBlocksMixin : UIView <ArvoDrawRectWithBlocks>
+    @interface THDrawRectWithBlocksMixin : UIView <THDrawRectWithBlocks>
     @end
 
 Implemented like this:
@@ -114,7 +114,7 @@ Implemented like this:
 
 You can then instantiate objects using the -allocWithSuperclass: method.  For example, this will create a UIButton that has the methods from your THDrawRectWithBlocks class:
 
-    UIButton<THDrawRectWithBlocks> *button = [(UIButton<THDrawRectWithBlocks> *)[ArvoDrawRectWithBlocksMixin allocWithSuperclass:[UIButton class]] initWithFrame:self.view.bounds];
+    UIButton<THDrawRectWithBlocks> *button = [(UIButton<THDrawRectWithBlocks> *)[THDrawRectWithBlocksMixin allocWithSuperclass:[UIButton class]] initWithFrame:self.view.bounds];
     
     button.drawRectBlock = ^(UIView *view, CGRect rect) {
         [[UIColor redColor] set];


### PR DESCRIPTION
Hi,

I added dynamic subclassing to ObjectiveMixin, so that it's possible to mix in to individual objects at alloc/init time rather than doing it on a per-class basis.  I added examples to the README file.  Would love to see this, or something like it, merged into the original repo.

Jamie.
