### PR TITLE
Tests + doc for 'force' option

### DIFF
--- a/ObjectiveMixinTests/DestinationClass.m
+++ b/ObjectiveMixinTests/DestinationClass.m
@@ -11,4 +11,10 @@
 
 @implementation DestinationClass
 
+- (int) methodToBeOverridden
+{
+	NSLog(@"This method is the destination class version");
+	return 2;
+}
+
 @end

--- a/ObjectiveMixinTests/ObjectiveMixinTests.m
+++ b/ObjectiveMixinTests/ObjectiveMixinTests.m
@@ -28,6 +28,16 @@
 	[super tearDown];
 }
 
+- (void) testForce {
+	DestinationClass *dest = [[[DestinationClass alloc] init] autorelease];
+	
+	[Mixin from:[SourceClass class] into:[DestinationClass class] followInheritance:NO force:NO];
+	NSAssert([(id)dest methodToBeOverridden] == 2, @"With force=NO, Destination should've retained its methodToBeOverridden");
+	
+	[Mixin from:[SourceClass class] into:[DestinationClass class] followInheritance:NO force:YES];
+	NSAssert([(id)dest methodToBeOverridden] == 1, @"With force=YES, Destination should've adopted mixin's methodToBeOverridden");
+}
+
 - (void)testMethods {
 	DestinationClass* dest = [[[DestinationClass alloc] init] autorelease];
 	
@@ -40,7 +50,7 @@
 - (void) testInheritedMethods {
 	DestinationClass* dest = [[[DestinationClass alloc] init] autorelease];
 	
-	[Mixin from:[ChildSourceClass class] into:[DestinationClass class] followInheritance:YES force:YES];
+	[Mixin from:[ChildSourceClass class] into:[DestinationClass class] followInheritance:YES force:NO];
 	[(id)dest childMethodCallingParentMethod];
 	[(id)dest helloWorld];
 }

--- a/ObjectiveMixinTests/SourceClass.h
+++ b/ObjectiveMixinTests/SourceClass.h
@@ -16,5 +16,6 @@
 - (void) helloWorld;
 - (void) methodWithAnArgument:(NSObject*)arg;
 - (void) methodUsingAnInstanceVariable;
+- (int) methodToBeOverridden;
 
 @end

--- a/ObjectiveMixinTests/SourceClass.m
+++ b/ObjectiveMixinTests/SourceClass.m
@@ -25,6 +25,12 @@
 	NSLog(@"This method uses an instance variable which has the following value: %@", jazzatazz);
 }
 
+- (int) methodToBeOverridden
+{
+	NSLog(@"This method is the source class version");
+	return 1;
+}
+
 - (void) dealloc {
     self.jazzatazz = nil;
     [super dealloc];


### PR DESCRIPTION
By the way, I should say that testing can get tricky since just doing a Mixin once will affect the rest of the runtime, so the latter methods actually aren't testing much. For instance, in `testNSObjectCategory`:

``` objc
- (void) testNSObjectCategory {
    DestinationClass* dest = [[[DestinationClass alloc] init] autorelease];
    // [dest mixinFrom:[SourceClass class]];

    [(id)dest helloWorld];
}
```

You can comment out the the third line and it'll still work since the classes have already been mixed in in previous tests.

I'm not sure how to solve this without making separate classes per test case. Or, writing a method to remove the effects of a mixin, but I can't see how that could be useful in normal use. Regardless, it's not a huge deal, just kind of cute. :)
